### PR TITLE
Make `pycolmap` importable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *.sw*
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # pycolmap
-Python interface for COLMAP reconstructions, plus some convenient scripts for loading/modifying/converting reconstructions.
+Python interface for COLMAP reconstructions, plus some convenient scripts for
+loading/modifying/converting reconstructions.
 
-This code does not, however, run reconstruction -- it only provides a convenient interface for handling COLMAP's output.
+This code does not, however, run reconstruction -- it only provides a
+convenient interface for handling COLMAP's output.
+
+## Installation
+
+The following works with `setuptools >= 62.0.0`. Run `python3 -m pip install
+setuptools --upgrade` if necessary.
+
+```
+git clone https://github.com/rmbrualla/pycolmap.git
+cd pycolmap
+python3 -m pip install -e .
+```
+

--- a/pycolmap/__init__.py
+++ b/pycolmap/__init__.py
@@ -1,5 +1,5 @@
-from camera import Camera
-from database import COLMAPDatabase
-from image import Image
-from scene_manager import SceneManager
-from rotation import Quaternion, DualQuaternion
+from .camera import Camera
+from .database import COLMAPDatabase
+from .image import Image
+from .scene_manager import SceneManager
+from .rotation import Quaternion, DualQuaternion

--- a/pycolmap/scene_manager.py
+++ b/pycolmap/scene_manager.py
@@ -8,9 +8,9 @@ import struct
 from collections import OrderedDict
 from itertools import combinations
 
-from camera import Camera
-from image import Image
-from rotation import Quaternion
+from .camera import Camera
+from .image import Image
+from .rotation import Quaternion
 
 #-------------------------------------------------------------------------------
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-
-
 [project]
 name = "pycolmap"
 version = "0.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+
+
+[project]
+name = "pycolmap"
+version = "0.0.1"
+dependencies = [
+    "numpy",
+    "scipy",
+]
+authors = [
+    {name = "Ricardo Martin-Brualla"},
+]
+description = "A Python API for reading and writing COLMAP-generated files."
+
+license = {file = "LICENSE.txt"}
+readme = "README.md"
+


### PR DESCRIPTION
After this PR, this version of `pycolmap` can be checked out and (locally) installed as a normal Python library.

```
$ pip install -e .  # installs pycolmap and its dependencies
$ cd ~
$ python
>>> from pycolmap import SceneManager  # <class 'pycolmap.scene_manager.SceneManager>
```