### PR TITLE
Correct binary loader

### DIFF
--- a/pycolmap/scene_manager.py
+++ b/pycolmap/scene_manager.py
@@ -99,10 +99,10 @@ class SceneManager:
         self.cameras = OrderedDict()
 
         with open(input_file, 'rb') as f:
-            num_cameras = struct.unpack('L', f.read(8))[0]
+            num_cameras = struct.unpack('Q', f.read(8))[0]
 
             for _ in range(num_cameras):
-                camera_id, camera_type, w, h = struct.unpack('IiLL', f.read(24))
+                camera_id, camera_type, w, h = struct.unpack('IiQQ', f.read(24))
                 num_params = Camera.GetNumParams(camera_type)
                 params = struct.unpack('d' * num_params, f.read(8 * num_params))
                 self.cameras[camera_id] = Camera(camera_type, w, h, params)
@@ -140,7 +140,7 @@ class SceneManager:
         self.images = OrderedDict()
 
         with open(input_file, 'rb') as f:
-            num_images = struct.unpack('L', f.read(8))[0]
+            num_images = struct.unpack('Q', f.read(8))[0]
             image_struct = struct.Struct('<I 4d 3d I')
             for _ in range(num_images):
                 data = image_struct.unpack(f.read(image_struct.size))
@@ -228,7 +228,7 @@ class SceneManager:
 
     def _load_points3D_bin(self, input_file):
         with open(input_file, 'rb') as f:
-            num_points3D = struct.unpack('L', f.read(8))[0]
+            num_points3D = struct.unpack('Q', f.read(8))[0]
 
             self.points3D = np.empty((num_points3D, 3))
             self.point3D_ids = np.empty(num_points3D, dtype=np.uint64)


### PR DESCRIPTION
The binary file loader seemed broken. Indeed [python documentation](https://docs.python.org/3/library/struct.html#struct-format-strings) indicates that "L" should be 4 bytes instead of 8. I assume that an unsinged long / uint64 was intended and changed the parsing accordingly. 

With this change the dataset tandt_db obtained from https://github.com/graphdeco-inria/gaussian-splatting seemed to work now.

I stumbled upon this when attempting to run https://github.com/nerfstudio-project/gsplat/tree/main/examples which depends on this repo.