### PR TITLE
OverflowError: Python integer -1 out of bounds for uint64

### DIFF
--- a/pycolmap/scene_manager.py
+++ b/pycolmap/scene_manager.py
@@ -19,7 +19,7 @@ from .rotation import Quaternion
 #-------------------------------------------------------------------------------
 
 class SceneManager:
-    INVALID_POINT3D = np.uint64(-1)
+    INVALID_POINT3D = np.int64(-1)
 
     def __init__(self, colmap_results_folder, image_path=None):
         self.folder = colmap_results_folder


### PR DESCRIPTION
SceneManager initializes with an invalid uint value that causes an error an import. Point3d uses -1, so this solution should work