### PR TITLE
Fix out of bounds error

### DIFF
--- a/pycolmap/scene_manager.py
+++ b/pycolmap/scene_manager.py
@@ -19,7 +19,7 @@ from .rotation import Quaternion
 #-------------------------------------------------------------------------------
 
 class SceneManager:
-    INVALID_POINT3D = np.uint64(-1)
+    INVALID_POINT3D = np.int64(-1)
 
     def __init__(self, colmap_results_folder, image_path=None):
         self.folder = colmap_results_folder


### PR DESCRIPTION
Fixing the following error:

```
pycolmap/scene_manager.py", line 22, in SceneManager
    INVALID_POINT3D = np.uint64(-1)
                      ^^^^^^^^^^^^^
OverflowError: Python integer -1 out of bounds for uint64
```