### PR TITLE
Handle txt colmap files with python 3

### DIFF
--- a/pycolmap/scene_manager.py
+++ b/pycolmap/scene_manager.py
@@ -116,10 +116,10 @@ class SceneManager:
                 if not line or line.startswith('#'):
                     continue
 
-                data = line.split()
+                data = np.array(line.split())
                 camera_id = int(data[0])
                 self.cameras[camera_id] = Camera(
-                    data[1], int(data[2]), int(data[3]), map(float, data[4:]))
+                    data[1], int(data[2]), int(data[3]), data[4:].astype(float))
                 self.last_camera_id = max(self.last_camera_id, camera_id)
 
     #---------------------------------------------------------------------------
@@ -190,17 +190,17 @@ class SceneManager:
 
                 is_camera_description_line = not is_camera_description_line
 
-                data = line.split()
+                data = np.array(line.split())
 
                 if is_camera_description_line:
                     image_id = int(data[0])
                     image = Image(data[-1], int(data[-2]),
-                                  Quaternion(np.array(map(float, data[1:5]))),
-                                  np.array(map(float, data[5:8])))
+                                  Quaternion(data[1:5].astype(float)),
+                                  data[5:8].astype(float))
                 else:
                     image.points2D = np.array(
-                        [map(float, data[::3]), map(float, data[1::3])]).T
-                    image.point3D_ids = np.array(map(np.uint64, data[2::3]))
+                        [data[::3].astype(float), data[1::3].astype(float)]).T
+                    image.point3D_ids = data[2::3].astype(np.uint64)
 
                     # automatically remove points without an associated 3D point
                     #mask = (image.point3D_ids != SceneManager.INVALID_POINT3D)
@@ -267,18 +267,18 @@ class SceneManager:
                 if not line or line.startswith('#'):
                     continue
 
-                data = line.split()
+                data = np.array(line.split())
                 point3D_id = np.uint64(data[0])
 
                 self.point3D_ids.append(point3D_id)
                 self.point3D_id_to_point3D_idx[point3D_id] = len(self.points3D)
-                self.points3D.append(map(np.float64, data[1:4]))
-                self.point3D_colors.append(map(np.uint8, data[4:7]))
+                self.points3D.append(data[1:4].astype(np.float64))
+                self.point3D_colors.append(data[4:7].astype(np.uint8))
                 self.point3D_errors.append(np.float64(data[7]))
 
                 # load (image id, point2D idx) pairs
                 self.point3D_id_to_images[point3D_id] = \
-                    np.array(map(np.uint32, data[8:])).reshape(-1, 2)
+                    data[8:].astype(np.uint32).reshape(-1, 2)
 
         self.points3D = np.array(self.points3D)
         self.point3D_ids = np.array(self.point3D_ids)


### PR DESCRIPTION
When using txt colmaps file I get `Exception: Input quaternion should be a 3- or 4-vector` error.

The problematic code is for example `np.array(map(float, data[1:5]))` which
- returned an array in python 2 but
- returns a map in python 3

=> we should use instead `np.array(data[1:5]).astype(float)`

to quickly try:

python 2.7
```python
>>> import numpy as np
>>> np.array(map(float, ['-1.0', '0.0', '1.0', '2.0']))
array([-1.,  0.,  1.,  2.])
```

python 3.10
```python
>>> import numpy as np
>>> np.array(map(float, ['-1.0', '0.0', '1.0', '2.0']))
array(<map object at 0x7fc17c3eb940>, dtype=object)
```

Related with https://github.com/nerfstudio-project/gsplat/issues/415